### PR TITLE
Fix bug in sum of products

### DIFF
--- a/scripts/gen_fp.sage
+++ b/scripts/gen_fp.sage
@@ -12,10 +12,10 @@ def fmt_little_u64(res, words):
         num = r[2:]
         new_num = num.zfill(16)
         new_num = new_num.upper()
-        new_num = "0x" + new_num + "u64"
+        new_num = "0x" + new_num
         out.append(new_num)
     while len(out) != words:
-        out.append("0x" + "0" * 16 + "u64")
+        out.append("0x" + "0" * 16)
     return out
 
 def fmt_list(l):
@@ -52,23 +52,27 @@ if __name__ == "__main__":
             nqr = i
             break
 
-    str = f"""
-    // Fp{BITLEN}: a finite field element GF(p) with p = 3 mod 4.
-    // Contents are opaque, all functions are constant-time.
+    output = f"""
+mod fp{BITLEN} {{
+    // Macro input generated with scripts/gen_fp.sage
+
+    // Field modulus
+    const MODULUS: [u64; {words}] = [{MODULUS}];
+
     fp2_rs::define_fp_core!(
         typename = Fp{BITLEN},
-        modulus = [{MODULUS}],
+        modulus = MODULUS,
     );
 
-    // Fp{BITLEN}Ext: a finite field element GF(p^2) with modulus x^2 + 1.
-    // Contents are opaque, all functions are constant-time.
-    fp2_rs::define_fp2_core!(
+    fp2_rs::define_fp2_from_modulus!(
         typename = Fp{BITLEN}Ext,
-        base_field = Fp{BITLEN},
+        base_typename = Fp{BITLEN},
+        modulus = MODULUS,
     );
 
-    fp2_rs::define_fp_tests!(Fp139);
+    fp2_rs::define_fp_tests!(Fp{BITLEN});
     fp2_rs::define_fp2_tests!(Fp{BITLEN}Ext, {nqr});
+}}
     """
 
-    print(str)
+    print(output)

--- a/src/fp2_gen.rs
+++ b/src/fp2_gen.rs
@@ -202,7 +202,7 @@ macro_rules! define_fp2_from_type {
             // algorithm which efficiently computes sums and differences of
             // products. For more information, see the `sum_of_products()`
             // function in `fp_gen.rs`.
-            fn set_mul_old(&mut self, rhs: &Self) {
+            fn set_mul_schoolbook(&mut self, rhs: &Self) {
                 // a <- x0*y0
                 // b <- x1*y1
                 // c <- (x0 + x1)*(y0 + y1)
@@ -218,15 +218,8 @@ macro_rules! define_fp2_from_type {
                 self.x1 -= &b;
             }
 
-            #[inline]
-            fn mul_old(self, rhs: Self) -> Self {
-                let mut r = self;
-                r.set_mul_old(&rhs);
-                r
-            }
-
             #[inline(always)]
-            fn set_mul(&mut self, rhs: &Self) {
+            fn set_mul_products(&mut self, rhs: &Self) {
                 // Computes x*y from:
                 // x = (x0 + i*x1)
                 // y = (y0 + i*y1)
@@ -241,10 +234,28 @@ macro_rules! define_fp2_from_type {
                 self.x1 = x1;
             }
 
+            #[inline(always)]
+            fn set_mul(&mut self, rhs: &Self) {
+                // If the sum of products needs additional subtractions, then
+                // most of the time schoolbook is better.
+                if <$Fp>::SUM_OF_PRODUCTS_ADDITIONAL_SUB {
+                    self.set_mul_schoolbook(rhs);
+                } else {
+                    self.set_mul_products(rhs);
+                }
+            }
+
             #[inline]
-            fn mul_new(self, rhs: Self) -> Self {
+            fn mul_schoolbook(self, rhs: Self) -> Self {
                 let mut r = self;
-                r.set_mul(&rhs);
+                r.set_mul_schoolbook(&rhs);
+                r
+            }
+
+            #[inline]
+            fn mul_sum_of_products(self, rhs: Self) -> Self {
+                let mut r = self;
+                r.set_mul_products(&rhs);
                 r
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 // defined within the Fq trait
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
+#![recursion_limit = "256"]
 
 pub mod fp2_gen;
 pub mod fp_gen;

--- a/tests/test_fields.rs
+++ b/tests/test_fields.rs
@@ -16,6 +16,11 @@ mod tests {
         // Macro input generated with scripts/gen_fp.sage
         fp2::define_fp2_from_modulus!(typename = FpUglyExt, base_typename = Fp, modulus = MODULUS,);
         fp2::define_fp2_tests!(FpUglyExt, MODULUS, 1);
+
+        #[test]
+        fn check_sum_of_products_flag() {
+            assert!(!FpUgly::SUM_OF_PRODUCTS_ADDITIONAL_SUB);
+        }
     }
 
     mod fp127_tests {
@@ -34,6 +39,11 @@ mod tests {
         // Macro input generated with scripts/gen_fp.sage
         fp2::define_fp2_from_modulus!(typename = Fp127Ext, base_typename = Fp, modulus = MODULUS,);
         fp2::define_fp2_tests!(Fp127Ext, MODULUS, 2);
+
+        #[test]
+        fn check_sum_of_products_flag() {
+            assert!(!Fp127::SUM_OF_PRODUCTS_ADDITIONAL_SUB);
+        }
     }
 
     mod fp251_tests {
@@ -58,6 +68,11 @@ mod tests {
 
         fp2::define_fp_tests!(Fp251);
         fp2::define_fp2_tests!(Fp251Ext, MODULUS, 5);
+
+        #[test]
+        fn check_sum_of_products_flag() {
+            assert!(!Fp251::SUM_OF_PRODUCTS_ADDITIONAL_SUB);
+        }
     }
 
     mod fp383_tests {
@@ -86,6 +101,11 @@ mod tests {
         // nqr_re + i is a non-quadratic residue in Fp2
         fp2::define_fp_tests!(Fp383);
         fp2::define_fp2_tests!(Fp383Ext, MODULUS, 6);
+
+        #[test]
+        fn check_sum_of_products_flag() {
+            assert!(!Fp383::SUM_OF_PRODUCTS_ADDITIONAL_SUB);
+        }
     }
 
     mod fp434_tests {
@@ -111,5 +131,87 @@ mod tests {
         // nqr_re + i is a non-quadratic residue in Fp2
         fp2::define_fp_tests!(Fp434);
         fp2::define_fp2_tests!(Fp434Ext, MODULUS, 2);
+
+        #[test]
+        fn check_sum_of_products_flag() {
+            assert!(!Fp434::SUM_OF_PRODUCTS_ADDITIONAL_SUB);
+        }
+    }
+
+    // This modulus is very close to the value R = 2^(64 * 14) and so
+    // needs an extra conditional subtraction in the sum of products
+    // method.
+    mod fp896_tests {
+        const MODULUS: [u64; 14] = [
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xA7FFFFFFFFFFFFFF,
+        ];
+        // Fp896: a finite field element GF(p) with p = 3 mod 4.
+        // Contents are opaque, all functions are constant-time.
+        fp2::define_fp_core!(typename = Fp896, modulus = MODULUS,);
+
+        // Fp896Ext: a finite field element GF(p^2) with modulus x^2 + 1.
+        // Contents are opaque, all functions are constant-time.
+        fp2::define_fp2_from_type!(typename = Fp896Ext, base_field = Fp896,);
+
+        fp2::define_fp_tests!(Fp896);
+        fp2::define_fp2_tests!(Fp896Ext, MODULUS, 2);
+
+        #[test]
+        fn check_sum_of_products_flag() {
+            assert!(Fp896::SUM_OF_PRODUCTS_ADDITIONAL_SUB);
+        }
+    }
+
+    // When the word length is larger than 20, we slightly modify set_mul
+    mod fp1554_tests {
+        static MODULUS: [u64; 25] = [
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF,
+            0x0000000000047FFF,
+        ];
+        // Fp896: a finite field element GF(p) with p = 3 mod 4.
+        // Contents are opaque, all functions are constant-time.
+        fp2::define_fp_core!(typename = Fp1554, modulus = MODULUS,);
+        fp2::define_fp_tests!(Fp1554);
+
+        #[test]
+        fn check_sum_of_products_flag() {
+            assert!(!Fp1554::SUM_OF_PRODUCTS_ADDITIONAL_SUB);
+        }
     }
 }


### PR DESCRIPTION
When using the sum of products algorithm from https://eprint.iacr.org/2022/367.pdf there is a restriciton for canonical inputs that 2(p - 1)^2 < p*R, where R = 2^(64*n) for elements represented by n limbs.

This commit includes a prime of this form into the tests and refactors the sum of products method to gracefully handle this case, allowing for these forms of primes to be correctly built by the macro